### PR TITLE
hide publication date

### DIFF
--- a/07-Updates.qmd
+++ b/07-Updates.qmd
@@ -2,7 +2,7 @@
 
 *Significant changes to this Book of Church Order will be listed here. For a detailed diff hosted at Github, [click here](https://github.com/Evangel-Presbytery/evangel-bco).*
 
-* **Current version:** Migration to [Quarto](https://quarto.org/). September 24, 2025.
+* **Current version:** 
 * Amendment to BCO 26.1 regarding the notice required before congregational meetings. Ratified at the February 6, 2025 meeting of Presbytery.
 * Amendment to BCO 15.10 regarding special called meetings. Ratified at the June 6, 2024 meeting of Presbytery.
 * Amendments to BCO 6.3, 12.3 and 22.11 regarding the use of "Teaching Elder"; amendment to BCO 12.3 regarding who is required to preach at presbytery; amendment inserting a new section 29 on abortion to the BCO (subsequent sections, and all internal links, were re-numbered as a result). These amendments were ratified at the presbytery meeting held on October 6, 2023.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -2,11 +2,12 @@ project:
   type: book
   post-render: scripts/fix_links.py
 
+date: today
+date-format: "MMMM D, YYYY"
+
 book:
   title: "Evangel Presbytery Book of Church Order"
-  author: "Evangel Presbytery"
-  description: "This is the official Book of Church Order for Evangel Presbytery. You can always find the latest online version at https://bco.evangelpresbytery.com. A record of the changes can be found in the [Updates](07-Updates.qmd) section at the end of the book."
-  date: today
+  description: "<br>This is the official Book of Church Order for Evangel Presbytery. You can always find the latest online version at <https://bco.evangelpresbytery.com>. A record of the changes can be found in the [Updates](07-Updates.qmd) section at the end of the book. <p>Last updated on {{< meta date >}}.</p>"
   repo-url: https://github.com/Evangel-Presbytery/evangel-bylaws
   chapters:
     - index.qmd

--- a/style.css
+++ b/style.css
@@ -1,6 +1,9 @@
-/* Hide author and publication date meta on title page */
-.quarto-title-meta {
-    display: none;
+/* Hide publication meta-data on title page */
+.quarto-title-meta-heading {
+  display: none;
+}
+.quarto-title-meta-contents {
+  display: none;
 }
 /*--*/
 


### PR DESCRIPTION
This solves issue #8 

also...
- improve description to include last updated date
- remove update info about moving to quarto. I think we only want content changes noted, not technical changes.